### PR TITLE
Add subscribe --dangerously-encode-payloads-as-plain-text

### DIFF
--- a/cmd/subscribe/subscribe.go
+++ b/cmd/subscribe/subscribe.go
@@ -13,22 +13,13 @@ import (
 	devutil "github.com/projectriff/developer-utils/pkg"
 	client "github.com/projectriff/stream-client-go"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (
-	fromBeginning bool
-	streamGVRc    = schema.GroupVersionResource{
-		Group:    "streaming.projectriff.io",
-		Version:  "v1alpha1",
-		Resource: "streams",
-	}
-	secretGVRc = schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "secrets",
-	}
-	namespaceC string
+	fromBeginning                        bool
+	namespace                            string
+	dangerouslyEncodePayloadsAsPlainText bool
 )
 
 type Event struct {
@@ -50,9 +41,15 @@ var eventHandler = func(ctx context.Context, payload io.Reader, contentType stri
 		return err
 	}
 
-	payloadStr := base64.StdEncoding.EncodeToString(bytes)
+	var payloadStr string
+	if dangerouslyEncodePayloadsAsPlainText {
+		payloadStr = string(bytes)
+	} else {
+		payloadStr = base64.StdEncoding.EncodeToString(bytes)
+	}
+
 	if headers == nil {
-		headers = make(map[string]string, 0)
+		headers = map[string]string{}
 	}
 
 	evt := Event{
@@ -85,13 +82,13 @@ var subscribeCmd = &cobra.Command{
 		}()
 
 		k8sClient := devutil.NewK8sClient()
-		secretName, err := k8sClient.GetNestedString(args[0], namespaceC, streamGVRc, "status", "binding", "secretRef", "name")
+		secretName, err := k8sClient.GetNestedString(args[0], namespace, devutil.StreamGVR, "status", "binding", "secretRef", "name")
 		if err != nil {
 			fmt.Println("error while finding binding secret reference", err)
 			os.Exit(1)
 		}
 
-		encodedTopic, err := k8sClient.GetNestedString(secretName, namespaceC, secretGVRc, "data", "topic")
+		encodedTopic, err := k8sClient.GetNestedString(secretName, namespace, devutil.SecretGVR, "data", "topic")
 		if err != nil {
 			fmt.Println("error while determining gateway topic for stream", err)
 			os.Exit(1)
@@ -103,7 +100,7 @@ var subscribeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		encodedGateway, err := k8sClient.GetNestedString(secretName, namespaceC, secretGVRc, "data", "gateway")
+		encodedGateway, err := k8sClient.GetNestedString(secretName, namespace, devutil.SecretGVR, "data", "gateway")
 		if err != nil {
 			fmt.Println("error while determining gateway address for stream", err)
 			os.Exit(1)
@@ -115,7 +112,7 @@ var subscribeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		contentType, err := k8sClient.GetNestedString(args[0], namespaceC, streamGVRc, "spec", "contentType")
+		contentType, err := k8sClient.GetNestedString(args[0], namespace, devutil.StreamGVR, "spec", "contentType")
 		if err != nil {
 			fmt.Println("error while determining contentType for stream", err)
 			os.Exit(1)
@@ -142,5 +139,6 @@ var subscribeCmd = &cobra.Command{
 
 func init() {
 	subscribeCmd.Flags().BoolVarP(&fromBeginning, "from-beginning", "b", false, "read everything in the stream")
-	subscribeCmd.Flags().StringVarP(&namespaceC, "namespace", "n", "", "namespace of the stream")
+	subscribeCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace of the stream")
+	subscribeCmd.Flags().BoolVar(&dangerouslyEncodePayloadsAsPlainText, "dangerously-encode-payloads-as-plain-text", false, "treat raw payloads as plain text, by default payloads are base64 encoded. This option may corrupt your terminal if binary data is present in the stream")
 }

--- a/cmd/subscribe/subscribe.go
+++ b/cmd/subscribe/subscribe.go
@@ -17,9 +17,9 @@ import (
 )
 
 var (
-	fromBeginning                        bool
-	namespace                            string
-	dangerouslyEncodePayloadsAsPlainText bool
+	fromBeginning   bool
+	namespace       string
+	payloadEncoding string
 )
 
 type Event struct {
@@ -42,10 +42,13 @@ var eventHandler = func(ctx context.Context, payload io.Reader, contentType stri
 	}
 
 	var payloadStr string
-	if dangerouslyEncodePayloadsAsPlainText {
+	switch payloadEncoding {
+	case "raw":
 		payloadStr = string(bytes)
-	} else {
+	case "base64":
 		payloadStr = base64.StdEncoding.EncodeToString(bytes)
+	default:
+		return fmt.Errorf("unsupported --payload-encoding %q", payloadEncoding)
 	}
 
 	if headers == nil {
@@ -140,5 +143,5 @@ var subscribeCmd = &cobra.Command{
 func init() {
 	subscribeCmd.Flags().BoolVarP(&fromBeginning, "from-beginning", "b", false, "read everything in the stream")
 	subscribeCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace of the stream")
-	subscribeCmd.Flags().BoolVar(&dangerouslyEncodePayloadsAsPlainText, "dangerously-encode-payloads-as-plain-text", false, "treat raw payloads as plain text, by default payloads are base64 encoded. This option may corrupt your terminal if binary data is present in the stream")
+	subscribeCmd.Flags().StringVarP(&payloadEncoding, "payload-encoding", "p", "base64", "encoding for payload in emitted messages, one of 'base64' or 'raw'")
 }

--- a/pkg/k8s_client.go
+++ b/pkg/k8s_client.go
@@ -11,6 +11,18 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+var (
+	StreamGVR = schema.GroupVersionResource{
+		Group:    "streaming.projectriff.io",
+		Version:  "v1alpha1",
+		Resource: "streams",
+	}
+	SecretGVR = schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "secrets",
+	}
+)
+
 const namespaceFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 type K8sClient struct {
@@ -28,11 +40,11 @@ func NewK8sClient() *K8sClient {
 		panic(err.Error())
 	}
 	return &K8sClient{
-		dc:dynamicClient,
+		dc: dynamicClient,
 	}
 }
 
-func (c *K8sClient) GetNestedString(streamName, namespace string, gvr schema.GroupVersionResource, fields... string) (string, error) {
+func (c *K8sClient) GetNestedString(streamName, namespace string, gvr schema.GroupVersionResource, fields ...string) (string, error) {
 	ns, err := resolveNamespace(namespace)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The subscribe command base64 encodes payloads before emitting them to
the console. This can be annoying if you know the payloads are actually
plain text.

The --dangerously-encode-payloads-as-plain-text will instead treat the
payload as plain text. If the stream contains binary data, it may
corrupt your terminal.